### PR TITLE
Correct tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - nightly
+
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
+  - cd $TRAVIS_BUILD_DIR
+
+script:
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+
+after_success:
+  - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": ">=7.0",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,12 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^5.6 || ^7.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~5.0",
+        "ext-mbstring": "*"
     },
     "scripts": {
         "test": "phpunit",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true" backupGlobals="false" 
+<phpunit bootstrap="vendor/autoload.php" colors="true" backupGlobals="false"
          backupStaticAttributes="false" syntaxCheck="false">
     <testsuites>
         <testsuite name="Tests">
@@ -9,15 +9,6 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
-            <exclude>
-                <directory>bin</directory>
-                <directory>build</directory>
-                <directory>docs</directory>
-                <directory>public</directory>
-                <directory>resources</directory>
-                <directory>tmp</directory>
-                <directory>vendor</directory>
-            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/util.php
+++ b/src/util.php
@@ -179,5 +179,9 @@ function encode_iso($data)
  */
 function read($file)
 {
+    if(!file_exists($file)) {
+        throw new \InvalidArgumentException('file'.$file.' is not found.');
+    }
+
     return require $file;
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -5,37 +5,12 @@ namespace Odan\Util\Test;
 /**
  * UtilTest
  */
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends \PHPUnit\Framework\TestCase
 {
 
     /**
      * Test.
      *
-     * @covers ::gh
-     * @return void
-     */
-    public function testGh()
-    {
-        $this->assertSame('', gh(null));
-        $this->assertSame('', gh(''));
-        $this->assertSame('abc', gh('abc'));
-    }
-
-    /**
-     * Test.
-     *
-     * @covers ::wh
-     * @return void
-     */
-    public function testWh()
-    {
-        $this->assertSame(null, wh(null));
-    }
-
-    /**
-     * Test.
-     *
-     * @covers ::now
      * @return void
      */
     public function testNow()
@@ -46,7 +21,6 @@ class UtilTest extends \PHPUnit_Framework_TestCase
     /**
      * Test.
      *
-     * @covers ::uuid
      * @return void
      */
     public function testUuid()
@@ -58,10 +32,9 @@ class UtilTest extends \PHPUnit_Framework_TestCase
     /**
      * Test.
      *
-     * @covers ::value
      * @return void
      */
-    public function testValue()
+    public function testArrayValue()
     {
         $arr = array(
             'key' => 1,
@@ -69,9 +42,111 @@ class UtilTest extends \PHPUnit_Framework_TestCase
                 'sub2' => 'test'
             )
         );
-        $this->assertSame(1, value($arr, 'key'));
-        $this->assertSame(null, value($arr, 'nada'));
-        $this->assertSame('test', value($arr, 'sub.sub2'));
+        $this->assertSame(1, array_value($arr, 'key'));
+        $this->assertSame(null, array_value($arr, 'nada'));
+        $this->assertSame('test', array_value($arr, 'sub.sub2'));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testArrayValueWithNotArrayArgument()
+    {
+        $this->assertNull(array_value('invalid_array', 'path'));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testHtml()
+    {
+        $this->assertInternalType('string', html('<script></script>'));
+        $this->assertSame('&lt;script&gt;&lt;/script&gt;', html('<script></script>'));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testIsEmail()
+    {
+        $this->assertTrue(is_email('name@example.com'));
+        $this->assertFalse(is_email('invalid_email_address'));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testEncodeJson()
+    {
+        $jsonArr = array(
+            'key1' => 'value1',
+            'key2' => 'value2',
+        );
+        $this->assertSame('{"key1":"value1","key2":"value2"}', encode_json($jsonArr));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testDecodeJson()
+    {
+        $jsonStr = '{"key1":"value1","key2":"value2"}';
+        $decodeArr = decode_json($jsonStr, true);
+        $this->assertArrayHasKey('key1', $decodeArr);
+        $this->assertArrayHasKey('key2', $decodeArr);
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testEncodeUtf8WithNullArgument()
+    {
+        $this->assertSame('', encode_utf8(''));
+        $this->assertNull(encode_utf8(null));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testEncodeIsoWithNullArgument()
+    {
+        $this->assertSame('', encode_iso(''));
+        $this->assertNull(encode_iso(null));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testEncodeIsoWithArrayArgument()
+    {
+        $isoResult = encode_iso(array('123'));
+        $this->assertSame('123', $isoResult[0]);
+    }
+
+    /**
+     * Test.
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testReadWithErrorFilePath()
+    {
+        read('./error_file_path');
     }
 
 }


### PR DESCRIPTION
# Change log
- remove the ```@covers``` annotation because the coverage range has already defined in the ```phpunit.xml```.
- change into the new released PHPUnit namespace.
- improve testings and add the correct function tests.
- add the ```.travis.yml``` to integrate the CI service. (see this Travis [build](https://travis-ci.org/peter279k/util).)
- check the ```mbstring``` extension whether it's installed during executing the Composer.
- Because the ```random_int``` is supported since PHP 7, the ```require``` change into ```>=7.0```.
